### PR TITLE
AM-113: Some commands failed with Turkish locale

### DIFF
--- a/src/main/scripts/addon
+++ b/src/main/scripts/addon
@@ -99,4 +99,4 @@ if [ -f "$PLF_HOME/addons/addons-manager.jar.new" ]; then
   mv "$PLF_HOME/addons/addons-manager.jar.new" "$PLF_HOME/addons/addons-manager.jar"
 fi
 
-eval exec \"$_RUNJAVA\" -Dplf.home=\"$PLF_HOME\" -jar \"$PLF_HOME/addons/addons-manager.jar\" "$@"
+eval exec \"$_RUNJAVA\" -Dplf.home=\"$PLF_HOME\" -Duser.language=\"en\" -jar \"$PLF_HOME/addons/addons-manager.jar\" "$@"

--- a/src/main/scripts/addon.bat
+++ b/src/main/scripts/addon.bat
@@ -107,7 +107,7 @@ if not exist "%PLF_HOME%\addons\addons-manager.jar.new" goto execCmd
 move /y "%PLF_HOME%\addons\addons-manager.jar.new" "%PLF_HOME%\addons\addons-manager.jar"
 
 :execCmd
-%_RUNJAVA% -Dplf.home="%PLF_HOME%" -jar "%PLF_HOME%\addons\addons-manager.jar" %CMD_LINE_ARGS%
+%_RUNJAVA% -Dplf.home="%PLF_HOME%" -Duser.language="en" -jar "%PLF_HOME%\addons\addons-manager.jar" %CMD_LINE_ARGS%
 goto end
 
 :exit

--- a/src/test/groovy/org/exoplatform/platform/am/AddonServiceTest.groovy
+++ b/src/test/groovy/org/exoplatform/platform/am/AddonServiceTest.groovy
@@ -191,6 +191,24 @@ class AddonServiceTest extends UnitTestsSpecification {
     thrown(InvalidJSONException)
   }
 
+  def "createAddonFromJsonText parse an invalid JSON text containing İ in Turkish"() {
+    when:
+    addonService.createAddonFromJsonText("""
+    {
+        "id": "my-addon",
+        "version": "1.0.0",
+        "name": "The super add-on Turkish",
+        "downloadUrl": "http://path/to/archive.zip",
+        "vendor": "eXo platform",
+        "license": "LGPLv3",
+        "supportedDistributions": "ENTERPRİSE,COMMUNİTY",
+        "supportedApplicationServers": "TOMCAT,JBOSS"
+    }
+""")
+    then:
+    thrown(InvalidJSONException)
+  }
+
   def "createAddonsFromJsonText must silently ignore all invalid entries"() {
     when:
     def addons = addonService.createAddonsFromJsonText("""


### PR DESCRIPTION
Fix description:
- Force Java system language as ENGLISH in addon script.
- Add unit test.
