### PR TITLE
AM-135: [Bitnami] Install & Uninstall don't work with war files

### DIFF
--- a/src/main/groovy/org/exoplatform/platform/am/AddonInstallService.groovy
+++ b/src/main/groovy/org/exoplatform/platform/am/AddonInstallService.groovy
@@ -242,7 +242,7 @@ public class AddonInstallService {
             destinationFile = new File(env.platform.homeDirectory, entry.name)
           }
           LOG.debug("Destination : ${destinationFile}")
-          String plfHomeRelativePath = env.platform.homeDirectory.toURI().relativize(destinationFile.toURI()).getPath()
+          String plfHomeRelativePath = destinationFile.getPath().substring(env.platform.homeDirectory.getPath().length() + 1)
           if (destinationFile.exists()) {
             conflictingFiles << plfHomeRelativePath
           }

--- a/src/main/groovy/org/exoplatform/platform/am/AddonInstallService.groovy
+++ b/src/main/groovy/org/exoplatform/platform/am/AddonInstallService.groovy
@@ -242,7 +242,7 @@ public class AddonInstallService {
             destinationFile = new File(env.platform.homeDirectory, entry.name)
           }
           LOG.debug("Destination : ${destinationFile}")
-          String plfHomeRelativePath = destinationFile.getPath().substring(env.platform.homeDirectory.getPath().length() + 1)
+          String plfHomeRelativePath = destinationFile.toURI().getPath().substring(env.platform.homeDirectory.toURI().getPath().length())
           if (destinationFile.exists()) {
             conflictingFiles << plfHomeRelativePath
           }
@@ -298,7 +298,7 @@ public class AddonInstallService {
           if (!destinationFile.parentFile.exists()) {
             FileUtils.mkdirs(destinationFile.parentFile)
           }
-          String plfHomeRelativePath = destinationFile.getPath().substring(env.platform.homeDirectory.getPath().length() + 1)
+          String plfHomeRelativePath = destinationFile.toURI().getPath().substring(env.platform.homeDirectory.toURI().getPath().length())
           if (destinationFile.exists()) {
             switch (conflict) {
               case Conflict.OVERWRITE:

--- a/src/main/groovy/org/exoplatform/platform/am/AddonInstallService.groovy
+++ b/src/main/groovy/org/exoplatform/platform/am/AddonInstallService.groovy
@@ -298,13 +298,19 @@ public class AddonInstallService {
           if (!destinationFile.parentFile.exists()) {
             FileUtils.mkdirs(destinationFile.parentFile)
           }
-          String plfHomeRelativePath = env.platform.homeDirectory.toURI().relativize(destinationFile.toURI()).getPath()
+          String plfHomeRelativePath = destinationFile.getPath().substring(env.platform.homeDirectory.getPath().length() + 1)
           if (destinationFile.exists()) {
             switch (conflict) {
               case Conflict.OVERWRITE:
-                LOG.warn("File ${plfHomeRelativePath} already exists. Overwritten.")
+                LOG.warn("File ${destinationFile} already exists. Overwritten.")
                 // Let's save it before
-                File backupFile = new File(env.overwrittenFilesDirectory, "${addon.id}/${plfHomeRelativePath}")
+                String pathInOverwrittenDir = plfHomeRelativePath.substring(0, plfHomeRelativePath.lastIndexOf("/") -1)
+                if (pathInOverwrittenDir.indexOf("/") < 0) {
+                  pathInOverwrittenDir = plfHomeRelativePath
+                } else {
+                  pathInOverwrittenDir = plfHomeRelativePath.substring(pathInOverwrittenDir.lastIndexOf("/") + 1)
+                }
+                File backupFile = new File(env.overwrittenFilesDirectory, "${addon.id}/${pathInOverwrittenDir}")
                 if (!backupFile.parentFile.exists()) {
                   FileUtils.mkdirs(backupFile.parentFile)
                 }

--- a/src/main/groovy/org/exoplatform/platform/am/AddonUninstallService.groovy
+++ b/src/main/groovy/org/exoplatform/platform/am/AddonUninstallService.groovy
@@ -98,9 +98,9 @@ public class AddonUninstallService {
       library ->
         File fileToDelete = new File(env.platform.homeDirectory, library)
         if (!fileToDelete.exists()) {
-          LOG.warn("No library ${library} to delete")
+          LOG.warn("No library ${fileToDelete} to delete")
         } else {
-          LOG.withStatus("Deleting library ${library}") {
+          LOG.withStatus("Deleting library ${fileToDelete}") {
             fileToDelete.delete()
             assert !fileToDelete.exists()
           }
@@ -116,9 +116,9 @@ public class AddonUninstallService {
         String webUri = webapp.substring(webapp.lastIndexOf('/')+1, webapp.length())
         File fileToDelete = new File(env.platform.homeDirectory, webapp)
         if (!fileToDelete.exists()) {
-          LOG.warn("No web application ${webapp} to delete")
+          LOG.warn("No web application ${fileToDelete} to delete")
         } else {
-          LOG.withStatus("Deleting web application ${webapp}") {
+          LOG.withStatus("Deleting web application ${fileToDelete}") {
             fileToDelete.delete()
             assert !fileToDelete.exists()
           }
@@ -163,7 +163,13 @@ public class AddonUninstallService {
     // Restore overwritten files
     addon.overwrittenFiles.each {
       fileToRecover ->
-        File backupFile = new File(env.overwrittenFilesDirectory, "${addon.id}/${fileToRecover}")
+        String pathInOverwrittenDir = fileToRecover.substring(0, fileToRecover.lastIndexOf("/") -1)
+        if (fileToRecover.indexOf("/") < 0) {
+          pathInOverwrittenDir = fileToRecover
+        } else {
+          pathInOverwrittenDir = fileToRecover.substring(pathInOverwrittenDir.lastIndexOf("/") + 1)
+        }
+        File backupFile = new File(env.overwrittenFilesDirectory, "${addon.id}/${pathInOverwrittenDir}")
         File originalFile = new File(env.platform.homeDirectory, fileToRecover)
         copyFile("Reinstalling original file ${fileToRecover}", backupFile, originalFile)
         LOG.withStatus("Deleting backup file of ${fileToRecover}") {


### PR DESCRIPTION
Problem description:
Webapp directory in case of Bitnami is outside Platform home directory. This results to 2 issues:
- Wrong relative path in install command, hence the error in uninstall command.
- Wrong file path inside overwrite directory.

Fix description:
- Update the way to get the relative path of a file with respect to Platform home directory.
- Update the file path inside the overwrite directory.
