### PR TITLE
PLF-8618 Move platform.properties to a more generic JAR

### DIFF
--- a/src/main/groovy/org/exoplatform/platform/am/settings/PlatformSettings.groovy
+++ b/src/main/groovy/org/exoplatform/platform/am/settings/PlatformSettings.groovy
@@ -138,7 +138,7 @@ class PlatformSettings {
           "Erroneous setup, platform properties directory (${this.propertiesDirectory}) is invalid.")
     }
 
-    Pattern filePattern = ~/platform-component-upgrade-plugins.*jar/
+    Pattern filePattern = ~/platform-extension-config.*jar/
     String fileFound
     Closure findFilenameClosure = {
       if (filePattern.matcher(it.name).find()) {
@@ -148,7 +148,7 @@ class PlatformSettings {
     this.librariesDirectory.eachFile(findFilenameClosure)
     if (fileFound == null) {
       throw new ErroneousSetupException(
-          "Erroneous setup, Unable to find platform-component-upgrade-plugins jar in ${librariesDirectory}")
+          "Erroneous setup, Unable to find platform-extension-config jar in ${librariesDirectory}")
     } else {
       JarFile jarFile = new JarFile(fileFound)
       JarEntry jarEntry = jarFile.getJarEntry("conf/platform.properties")


### PR DESCRIPTION
In order to improve dependencies of new Platform Community edition, the JARs included in this edition will be optimized to work with Social + GateIN only. To do this, the JAR `platform-component-upgrade-plugins` will be removed and move each class  / file of it into the dedicated project (ecms / social / calendar ... )
So the `platform.properties` will be moved as well to a more generic JAR that will be present in all distributions and which is dedicated to a configuration of both packages EE and CE. (The jar file will be `platform-extension-config`)